### PR TITLE
1.16.4 dust generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ build
 # other
 eclipse
 run
+build.bat
+setup.bat

--- a/src/main/java/com/rafacost3d/usrg/blocks/ClayGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/ClayGeneratorTile.java
@@ -1,6 +1,7 @@
 package com.rafacost3d.usrg.blocks;
 
 import net.minecraft.block.Blocks;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ITickableTileEntity;
@@ -15,11 +16,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class ClayGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public ClayGeneratorTile() {
         super(CLAYGENERATOR_TILE);
@@ -27,8 +33,12 @@ public class ClayGeneratorTile extends TileEntity implements ITickableTileEntity
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.CLAY, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.CLAY, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/ClayGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/ClayGeneratorTile.java
@@ -2,6 +2,7 @@ package com.rafacost3d.usrg.blocks;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -11,24 +12,32 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import com.rafacost3d.usrg.setup.Config;
 
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class ClayGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
-
+    
     public ClayGeneratorTile() {
         super(CLAYGENERATOR_TILE);
     }
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.CLAY, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	if (Config.GENERATE_DUST.get()) {
+            ItemStack stack = new ItemStack(Items.CLAY_BALL, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	} else {
+            ItemStack stack = new ItemStack(Blocks.CLAY, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	}
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/CobblestoneGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/CobblestoneGeneratorTile.java
@@ -17,11 +17,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.COBBLEGENERATOR_TILE;
 
 public class CobblestoneGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public CobblestoneGeneratorTile() {
         super(COBBLEGENERATOR_TILE);
@@ -29,8 +34,12 @@ public class CobblestoneGeneratorTile extends TileEntity implements ITickableTil
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.COBBLESTONE, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.COBBLESTONE, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/CrushedEndstoneGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/CrushedEndstoneGeneratorTile.java
@@ -18,11 +18,16 @@ import net.minecraftforge.registries.ForgeRegistries;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class CrushedEndstoneGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public CrushedEndstoneGeneratorTile() {
         super(ENDCRUSHEDGENERATOR_TILE);
@@ -30,17 +35,21 @@ public class CrushedEndstoneGeneratorTile extends TileEntity implements ITickabl
 
     @Override
     public void tick() {
-    	ResourceLocation key = new ResourceLocation("exnihilosequentia:crushed_end_stone");
-    	
-        if (ForgeRegistries.BLOCKS.containsKey(key)) {
-        	Block block = ForgeRegistries.BLOCKS.getValue(key);
-            ItemStack stack = new ItemStack(block, 1);
-            ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
-        } else {
-        	Block block = Blocks.END_STONE;
-            ItemStack stack = new ItemStack(block, 1);
-            ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
-        }     
+        if(tickcount % tickspergencycle == 0) {
+        	ResourceLocation key = new ResourceLocation("exnihilosequentia:crushed_end_stone");
+        	
+            if (ForgeRegistries.BLOCKS.containsKey(key)) {
+            	Block block = ForgeRegistries.BLOCKS.getValue(key);
+                ItemStack stack = new ItemStack(block, 1);
+                ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
+            } else {
+            	Block block = Blocks.END_STONE;
+                ItemStack stack = new ItemStack(block, 1);
+                ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
+            }
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/CrushedNetherGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/CrushedNetherGeneratorTile.java
@@ -18,11 +18,16 @@ import net.minecraftforge.registries.ForgeRegistries;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class CrushedNetherGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public CrushedNetherGeneratorTile() {
         super(NETHERCRUSHEDGENERATOR_TILE);
@@ -30,17 +35,21 @@ public class CrushedNetherGeneratorTile extends TileEntity implements ITickableT
 
     @Override
     public void tick() {
-    	ResourceLocation key = new ResourceLocation("exnihilosequentia:crushed_netherrack");
-    	
-        if (ForgeRegistries.BLOCKS.containsKey(key)) {
-        	Block block = ForgeRegistries.BLOCKS.getValue(key);
-            ItemStack stack = new ItemStack(block, 1);
-            ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
-        } else {
-        	Block block = Blocks.NETHERRACK;
-            ItemStack stack = new ItemStack(block, 1);
-            ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
+        if(tickcount % tickspergencycle == 0) {
+        	ResourceLocation key = new ResourceLocation("exnihilosequentia:crushed_netherrack");
+        	
+            if (ForgeRegistries.BLOCKS.containsKey(key)) {
+            	Block block = ForgeRegistries.BLOCKS.getValue(key);
+                ItemStack stack = new ItemStack(block, 1);
+                ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
+            } else {
+            	Block block = Blocks.NETHERRACK;
+                ItemStack stack = new ItemStack(block, 1);
+                ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
+            }
+            tickcount = 1;
         }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/DirtGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/DirtGeneratorTile.java
@@ -15,11 +15,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class DirtGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public DirtGeneratorTile() {
         super(DIRTGENERATOR_TILE);
@@ -27,8 +32,12 @@ public class DirtGeneratorTile extends TileEntity implements ITickableTileEntity
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.DIRT, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.DIRT, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/DustGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/DustGeneratorTile.java
@@ -18,11 +18,16 @@ import net.minecraftforge.registries.ForgeRegistries;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class DustGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public DustGeneratorTile() {
         super(DUSTGENERATOR_TILE);
@@ -30,17 +35,21 @@ public class DustGeneratorTile extends TileEntity implements ITickableTileEntity
 
     @Override
     public void tick() {
-    	ResourceLocation key = new ResourceLocation("exnihilosequentia:dust");
-    	
-        if (ForgeRegistries.BLOCKS.containsKey(key)) {
-        	Block block = ForgeRegistries.BLOCKS.getValue(key);
-            ItemStack stack = new ItemStack(block, 1);
-            ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
-        } else {
-        	Block block = Blocks.SAND;
-            ItemStack stack = new ItemStack(block, 1);
-            ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
-        }    	
+        if(tickcount % tickspergencycle == 0) {
+        	ResourceLocation key = new ResourceLocation("exnihilosequentia:dust");
+        	
+            if (ForgeRegistries.BLOCKS.containsKey(key)) {
+            	Block block = ForgeRegistries.BLOCKS.getValue(key);
+                ItemStack stack = new ItemStack(block, 1);
+                ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
+            } else {
+            	Block block = Blocks.SAND;
+                ItemStack stack = new ItemStack(block, 1);
+                ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
+            }    
+            tickcount = 1;
+        }
+        tickcount += 1;	
     }
 
     @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/EndstoneGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/EndstoneGeneratorTile.java
@@ -15,11 +15,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class EndstoneGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public EndstoneGeneratorTile() {
         super(ENDGENERATOR_TILE);
@@ -27,8 +32,12 @@ public class EndstoneGeneratorTile extends TileEntity implements ITickableTileEn
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.END_STONE, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.END_STONE, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/FungusGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/FungusGeneratorTile.java
@@ -15,11 +15,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class FungusGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public FungusGeneratorTile() {
         super(FUNGUSGENERATOR_TILE);
@@ -27,8 +32,12 @@ public class FungusGeneratorTile extends TileEntity implements ITickableTileEnti
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.MYCELIUM, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.MYCELIUM, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/GlowstoneGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/GlowstoneGeneratorTile.java
@@ -15,11 +15,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class GlowstoneGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public GlowstoneGeneratorTile() {
         super(GLOWSTONEGENERATOR_TILE);
@@ -27,8 +32,12 @@ public class GlowstoneGeneratorTile extends TileEntity implements ITickableTileE
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.GLOWSTONE, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.GLOWSTONE, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 //
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/GlowstoneGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/GlowstoneGeneratorTile.java
@@ -2,6 +2,7 @@ package com.rafacost3d.usrg.blocks;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -15,6 +16,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class GlowstoneGeneratorTile extends TileEntity implements ITickableTileEntity {
@@ -27,8 +30,13 @@ public class GlowstoneGeneratorTile extends TileEntity implements ITickableTileE
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.GLOWSTONE, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	if (Config.GENERATE_DUST.get()) {
+            ItemStack stack = new ItemStack(Items.GLOWSTONE_DUST, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	} else {
+            ItemStack stack = new ItemStack(Blocks.GLOWSTONE, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	}
     }
 //
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/GrassGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/GrassGeneratorTile.java
@@ -15,7 +15,7 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-
+import com.rafacost3d.usrg.setup.Config;
 
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
@@ -23,14 +23,21 @@ public class GrassGeneratorTile extends TileEntity implements ITickableTileEntit
 
     private ItemStackHandler handler;
 
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
+
     public GrassGeneratorTile() {
         super(GRASSGENERATOR_TILE);
     }
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.GRASS_BLOCK, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.GRASS_BLOCK, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/GravelGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/GravelGeneratorTile.java
@@ -15,11 +15,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class GravelGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public GravelGeneratorTile() {
         super(GRAVELGENERATOR_TILE);
@@ -27,8 +32,12 @@ public class GravelGeneratorTile extends TileEntity implements ITickableTileEnti
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.GRAVEL, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.GRAVEL, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/IceGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/IceGeneratorTile.java
@@ -15,11 +15,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class IceGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public IceGeneratorTile() {
         super(ICEGENERATOR_TILE);
@@ -27,8 +32,12 @@ public class IceGeneratorTile extends TileEntity implements ITickableTileEntity 
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.ICE, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.ICE, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/NetherGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/NetherGeneratorTile.java
@@ -15,11 +15,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class NetherGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public NetherGeneratorTile() {
         super(NETHERGENERATOR_TILE);
@@ -27,8 +32,12 @@ public class NetherGeneratorTile extends TileEntity implements ITickableTileEnti
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.NETHERRACK, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.NETHERRACK, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/ObsidianGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/ObsidianGeneratorTile.java
@@ -15,11 +15,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class ObsidianGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public ObsidianGeneratorTile() {
         super(OBSIDIANGENERATOR_TILE);
@@ -27,8 +32,12 @@ public class ObsidianGeneratorTile extends TileEntity implements ITickableTileEn
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.OBSIDIAN, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.OBSIDIAN, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/OreGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/OreGeneratorTile.java
@@ -33,6 +33,9 @@ public class OreGeneratorTile extends TileEntity implements ITickableTileEntity 
     private HashMap<Integer, Item> oreItems = new HashMap<Integer, Item>();
     private HashMap<Integer, Integer> oreProbs = new HashMap<Integer, Integer>();
 
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
+    
     public OreGeneratorTile() {
         super(OREGENERATOR_TILE);
         
@@ -137,18 +140,16 @@ public class OreGeneratorTile extends TileEntity implements ITickableTileEntity 
         return oreItems.get(key);
     }
 
-    private Integer count=0;
-    private Integer orepertick= Config.BLOCK_PER_TICK.get();
     @Override
     public void tick() {
-        if(count%orepertick == 0) {
+        if(tickcount % tickspergencycle == 0) {
         	Item item = rndOre();
         	if (item != null) {
                 ItemStack stack = new ItemStack(item, 1);
                 ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
         	}
         }
-        count+=1;
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/QuartzGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/QuartzGeneratorTile.java
@@ -15,11 +15,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class QuartzGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public QuartzGeneratorTile() {
         super(QUARTZGENERATOR_TILE);
@@ -27,8 +32,12 @@ public class QuartzGeneratorTile extends TileEntity implements ITickableTileEnti
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.QUARTZ_BLOCK, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.QUARTZ_BLOCK, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/QuartzGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/QuartzGeneratorTile.java
@@ -2,6 +2,7 @@ package com.rafacost3d.usrg.blocks;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -15,6 +16,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class QuartzGeneratorTile extends TileEntity implements ITickableTileEntity {
@@ -27,8 +30,13 @@ public class QuartzGeneratorTile extends TileEntity implements ITickableTileEnti
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.QUARTZ_BLOCK, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	if (Config.GENERATE_DUST.get()) {
+            ItemStack stack = new ItemStack(Items.QUARTZ, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	} else {
+            ItemStack stack = new ItemStack(Blocks.QUARTZ_BLOCK, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	}
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/RedstoneGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/RedstoneGeneratorTile.java
@@ -15,11 +15,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class RedstoneGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public RedstoneGeneratorTile() {
         super(REDSTONEGENERATOR_TILE);
@@ -27,8 +32,12 @@ public class RedstoneGeneratorTile extends TileEntity implements ITickableTileEn
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.REDSTONE_BLOCK, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.REDSTONE_BLOCK, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/RedstoneGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/RedstoneGeneratorTile.java
@@ -2,6 +2,7 @@ package com.rafacost3d.usrg.blocks;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -15,6 +16,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class RedstoneGeneratorTile extends TileEntity implements ITickableTileEntity {
@@ -27,8 +30,13 @@ public class RedstoneGeneratorTile extends TileEntity implements ITickableTileEn
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.REDSTONE_BLOCK, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	if (Config.GENERATE_DUST.get()) {
+            ItemStack stack = new ItemStack(Items.REDSTONE, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	} else {
+            ItemStack stack = new ItemStack(Blocks.REDSTONE_BLOCK, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	}
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/SandGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/SandGeneratorTile.java
@@ -15,11 +15,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class SandGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public SandGeneratorTile() {
         super(SANDGENERATOR_TILE);
@@ -27,8 +32,12 @@ public class SandGeneratorTile extends TileEntity implements ITickableTileEntity
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.SAND, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.SAND, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/SnowGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/SnowGeneratorTile.java
@@ -15,11 +15,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class SnowGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public SnowGeneratorTile() {
         super(SNOWGENERATOR_TILE);
@@ -27,8 +32,12 @@ public class SnowGeneratorTile extends TileEntity implements ITickableTileEntity
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.SNOW_BLOCK, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.SNOW_BLOCK, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/SnowGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/SnowGeneratorTile.java
@@ -2,6 +2,7 @@ package com.rafacost3d.usrg.blocks;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -15,6 +16,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class SnowGeneratorTile extends TileEntity implements ITickableTileEntity {
@@ -27,8 +30,13 @@ public class SnowGeneratorTile extends TileEntity implements ITickableTileEntity
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.SNOW_BLOCK, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	if (Config.GENERATE_DUST.get()) {
+            ItemStack stack = new ItemStack(Items.SNOWBALL, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	} else {
+            ItemStack stack = new ItemStack(Blocks.SNOW_BLOCK, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	}
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/SoulGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/SoulGeneratorTile.java
@@ -15,11 +15,16 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class SoulGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
+
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
 
     public SoulGeneratorTile() {
         super(SOULGENERATOR_TILE);
@@ -27,8 +32,12 @@ public class SoulGeneratorTile extends TileEntity implements ITickableTileEntity
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.SOUL_SAND, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+        if(tickcount % tickspergencycle == 0) {
+            ItemStack stack = new ItemStack(Blocks.SOUL_SAND, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+            tickcount = 1;
+        }
+        tickcount += 1;
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/setup/Config.java
+++ b/src/main/java/com/rafacost3d/usrg/setup/Config.java
@@ -31,7 +31,7 @@ public class Config {
 
     static {
         COMMON_BUILDER.comment("General Settings").push(CATEGORY_GENERAL);
-        BLOCK_PER_TICK = COMMON_BUILDER.comment("Ticks between Block Generated").defineInRange("blocks_per_tick", 40, 1, 2000);
+        BLOCK_PER_TICK = COMMON_BUILDER.comment("Ticks between each generation cycle.").defineInRange("blocks_per_tick", 40, 1, 2000);
         COMMON_BUILDER.pop();
 
         COMMON_BUILDER.comment("OreGenerator Settings").push(CATEGORY_OREGEN);

--- a/src/main/java/com/rafacost3d/usrg/setup/Config.java
+++ b/src/main/java/com/rafacost3d/usrg/setup/Config.java
@@ -25,13 +25,14 @@ public class Config {
     public static ForgeConfigSpec COMMON_CONFIG;
     public static ForgeConfigSpec CLIENT_CONFIG;
 
+    public static ForgeConfigSpec.BooleanValue GENERATE_DUST;
     public static ForgeConfigSpec.IntValue BLOCK_PER_TICK;
-    public static ForgeConfigSpec.IntValue ORE_PER_TICK;
     public static ForgeConfigSpec.ConfigValue<List<? extends String>> ORE_GENERATOR_ITEMS;
 
     static {
         COMMON_BUILDER.comment("General Settings").push(CATEGORY_GENERAL);
-        BLOCK_PER_TICK = COMMON_BUILDER.comment("Ticks between Block Generated").defineInRange("blocks_per_tick", 40, 1, 2000);
+        GENERATE_DUST = COMMON_BUILDER.comment("Clay, Glowstone, Quartz, Redstone and Snow Generators will generate dust items, not blocks.").define("generate_dust", false);
+        BLOCK_PER_TICK = COMMON_BUILDER.comment("Ticks between each generation cycle.").defineInRange("blocks_per_tick", 40, 1, 2000);
         COMMON_BUILDER.pop();
 
         COMMON_BUILDER.comment("OreGenerator Settings").push(CATEGORY_OREGEN);

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -45,7 +45,7 @@ displayName="Ultimate Skyblock Resource Generator" #mandatory
 # The description text for the mod (multi line!) (#mandatory)
 description='''
 The Ultimate Cobble, Gravel, Sand, Dirt, Grass, Mycelium, Obsidian, Ice and Snow Generator.
-If Ex Nihilo: Sequentia installed, includes Dust Generator.
+If Ex Nihilo: Sequentia installed, includes Dust, Crushed Endstone and Crushed Netherrack Generator.
 '''
 
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.

--- a/src/main/resources/data/usrg/recipes/endcrushedgenerator.json
+++ b/src/main/resources/data/usrg/recipes/endcrushedgenerator.json
@@ -1,4 +1,8 @@
 {
+  "conditions": [{
+    "type": "forge:item_exists",
+    "item": "exnihilosequentia:crushed_end_stone"
+  }],
   "type": "minecraft:crafting_shaped",
   "pattern": [
     "ppp",

--- a/src/main/resources/data/usrg/recipes/nethercrushedgenerator.json
+++ b/src/main/resources/data/usrg/recipes/nethercrushedgenerator.json
@@ -1,4 +1,8 @@
 {
+  "conditions": [{
+    "type": "forge:item_exists",
+    "item": "exnihilosequentia:crushed_netherrack"
+  }],
   "type": "minecraft:crafting_shaped",
   "pattern": [
     "ppp",


### PR DESCRIPTION
Added the ability to change specific generators to create dust variants, instead of the block.

1. Added config setting (GENERATE_DUST, True/False).
2. Updated Clay, Glowstone, Quartz, Redstone and Snow Generators to create dust item if new config setting is True, otherwise will generate the block.

NOTE: This does not include the changes for the tick generation check, this is the 1.16.4 branch with only this change.