### PR TITLE
Dye Generator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.16.4-3.0'
+version = '1.16.4-3.2'
 group = 'com.rafacost3d.usrg' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'Ultimate SkyBlock Resource Generator'
 

--- a/src/main/java/com/rafacost3d/usrg/USRG.java
+++ b/src/main/java/com/rafacost3d/usrg/USRG.java
@@ -71,9 +71,18 @@ public class USRG
             event.getRegistry().register(new SandGenerator());
             event.getRegistry().register(new SnowGenerator());
             event.getRegistry().register(new SoulGenerator());
-            event.getRegistry().register(new OreGenerator());
-            
-        	LOGGER.info("USRG - Vanilla Generator blocks registered");
+
+            LOGGER.info("USRG - Vanilla Generator blocks registered");
+
+            if (Config.ENABLE_ORE_GENERATOR.get()) {
+                event.getRegistry().register(new OreGenerator());
+                LOGGER.info("USRG - Ore Generator block registered");
+            }
+
+            if (Config.ENABLE_DYE_GENERATOR.get()) {
+                event.getRegistry().register(new DyeGenerator());
+                LOGGER.info("USRG - Dye Generator block registered");
+            }
 
             ResourceLocation key = new ResourceLocation("exnihilosequentia:dust");
             if (ForgeRegistries.BLOCKS.containsKey(key)) {
@@ -114,9 +123,18 @@ public class USRG
             event.getRegistry().register(new BlockItem(ModBlocks.SANDGENERATOR, properties).setRegistryName("sandgenerator"));
             event.getRegistry().register(new BlockItem(ModBlocks.SNOWGENERATOR, properties).setRegistryName("snowgenerator"));
             event.getRegistry().register(new BlockItem(ModBlocks.SOULGENERATOR, properties).setRegistryName("soulgenerator"));
-            event.getRegistry().register(new BlockItem(ModBlocks.OREGENERATOR, properties).setRegistryName("oregenerator"));
-            
-        	LOGGER.info("USRG - Vanilla Generator items registered");
+
+            LOGGER.info("USRG - Vanilla Generator items registered");
+
+            if (Config.ENABLE_ORE_GENERATOR.get()) {
+                event.getRegistry().register(new BlockItem(ModBlocks.OREGENERATOR, properties).setRegistryName("oregenerator"));
+                LOGGER.info("USRG - Ore Generator item registered");
+            }
+
+            if (Config.ENABLE_DYE_GENERATOR.get()) {
+                event.getRegistry().register(new BlockItem(ModBlocks.DYEGENERATOR, properties).setRegistryName("dyegenerator"));
+                LOGGER.info("USRG - Dye Generator item registered");
+            }
 
             ResourceLocation key = new ResourceLocation("exnihilosequentia:dust");
             if (ForgeRegistries.BLOCKS.containsKey(key)) {
@@ -155,9 +173,18 @@ public class USRG
             event.getRegistry().register(TileEntityType.Builder.create(SandGeneratorTile::new, ModBlocks.SANDGENERATOR).build(null).setRegistryName("sandgenerator"));
             event.getRegistry().register(TileEntityType.Builder.create(SnowGeneratorTile::new, ModBlocks.SNOWGENERATOR).build(null).setRegistryName("snowgenerator"));
             event.getRegistry().register(TileEntityType.Builder.create(SoulGeneratorTile::new, ModBlocks.SOULGENERATOR).build(null).setRegistryName("soulgenerator"));
-            event.getRegistry().register(TileEntityType.Builder.create(OreGeneratorTile::new, ModBlocks.OREGENERATOR).build(null).setRegistryName("oregenerator"));
-            
-        	LOGGER.info("USRG - Vanilla Generator tile entities registered");
+
+            LOGGER.info("USRG - Vanilla Generator tile entities registered");
+
+            if (Config.ENABLE_ORE_GENERATOR.get()) {
+                event.getRegistry().register(TileEntityType.Builder.create(OreGeneratorTile::new, ModBlocks.OREGENERATOR).build(null).setRegistryName("oregenerator"));
+                LOGGER.info("USRG - Ore Generator tile entity registered");
+            }
+
+            if (Config.ENABLE_DYE_GENERATOR.get()) {
+                event.getRegistry().register(TileEntityType.Builder.create(DyeGeneratorTile::new, ModBlocks.DYEGENERATOR).build(null).setRegistryName("dyegenerator"));
+                LOGGER.info("USRG - Dye Generator tile entity registered");
+            }
 
             ResourceLocation key = new ResourceLocation("exnihilosequentia:dust");
             if (ForgeRegistries.BLOCKS.containsKey(key)) {

--- a/src/main/java/com/rafacost3d/usrg/blocks/DyeGenerator.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/DyeGenerator.java
@@ -1,0 +1,62 @@
+package com.rafacost3d.usrg.blocks;
+
+import com.rafacost3d.usrg.setup.Config;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.SoundType;
+import net.minecraft.block.material.Material;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.client.util.InputMappings;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraft.world.IBlockReader;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import org.lwjgl.glfw.GLFW;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class DyeGenerator extends Block {
+    public DyeGenerator(){
+        super(Properties.create(Material.WOOL)
+                .sound(SoundType.CLOTH)
+                .hardnessAndResistance(2.0f)
+        );
+        setRegistryName("dyegenerator");
+    }
+
+    @Override
+    @OnlyIn(Dist.CLIENT)
+    public void addInformation(ItemStack stack, @Nullable IBlockReader worldIn, List<ITextComponent> tooltip, ITooltipFlag flags) {
+
+        if (InputMappings.isKeyDown(Minecraft.getInstance().getMainWindow().getHandle(), GLFW.GLFW_KEY_LEFT_SHIFT)) {
+            TranslationTextComponent information = new TranslationTextComponent("block.dyegenerator.information");
+
+            if (information != null) {
+                String text = information.getString();
+
+                text = text.replace("{ticks}", Config.BLOCK_PER_TICK.get().toString());
+
+                tooltip.add(new StringTextComponent(text));
+            }
+        } else {
+            tooltip.add(new TranslationTextComponent("block.holdshift.information"));
+        }
+    }
+
+    @Override
+    public boolean hasTileEntity(BlockState state) {
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public TileEntity createTileEntity(BlockState state, IBlockReader world) {
+        return new DyeGeneratorTile();
+    }
+}

--- a/src/main/java/com/rafacost3d/usrg/blocks/DyeGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/DyeGeneratorTile.java
@@ -1,0 +1,120 @@
+package com.rafacost3d.usrg.blocks;
+
+import com.rafacost3d.usrg.setup.Config;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.ITickableTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.Direction;
+import net.minecraftforge.common.Tags;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
+import net.minecraftforge.items.ItemStackHandler;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.HashMap;
+
+import static com.rafacost3d.usrg.blocks.ModBlocks.*;
+
+public class DyeGeneratorTile extends TileEntity implements ITickableTileEntity {
+	
+    private HashMap<Integer, Item> dyeItems = new HashMap<Integer, Item>();
+    private HashMap<Integer, Integer> dyeProbs = new HashMap<Integer, Integer>();
+
+    private ItemStackHandler handler;
+    private Integer tickcount = 0;
+    private Integer tickspergencycle = Config.BLOCK_PER_TICK.get();
+    
+    public DyeGeneratorTile() {
+        super(DYEGENERATOR_TILE);
+        
+        int key = 1;
+
+        for (Item item : Tags.Items.DYES.getAllElements()) {
+        	dyeItems.put(key, item);
+        	dyeProbs.put(key++, (int)(0.10 * 100));
+        }
+    }
+
+    static int findCeil(int arr[], int r, int l, int h) {
+        int mid;
+        
+        while (l < h) {
+            mid = l + ((h - l) >> 1);
+            if(r > arr[mid])
+                l = mid + 1;
+            else
+                h = mid;
+        }
+        
+        return (arr[l] >= r) ? l : -1;
+    }
+
+    static int myRand(int arr[]) {
+    	int n = arr.length;
+        int prefix[] = new int[n + 1];
+        
+        for (int i = 0; i < n; ++i) {
+            prefix[i + 1] = prefix[i] + arr[i];
+        }
+        
+        int r = ((int)(Math.random() * (323567)) % prefix[n]) + 1;
+
+        return findCeil(prefix, r, 0, n);
+    }
+
+    public Item rndDye(){
+    	int[] arr = new int[dyeProbs.size()];
+    	int index = 0;
+    	
+    	for (int key = 1; key <= dyeProbs.size(); key++) {
+    		if (dyeProbs.containsKey(key)) {
+    			arr[index] = dyeProbs.get(key);
+    		}
+    		index++;
+    	}
+    	
+        int key = myRand(arr);
+        return dyeItems.get(key);
+    }
+
+    @Override
+    public void tick() {
+        if(tickcount % tickspergencycle == 0) {
+        	Item item = rndDye();
+        	if (item != null) {
+                ItemStack stack = new ItemStack(item, 1);
+                ItemHandlerHelper.insertItemStacked(getHandler(), stack, false);
+        	}
+        }
+        tickcount += 1;
+    }
+
+    @Override
+    public CompoundNBT write(CompoundNBT tag) {
+        CompoundNBT compound = getHandler().serializeNBT();
+        tag.put("inv", compound);
+        return super.write(tag);
+    }
+
+    private ItemStackHandler getHandler(){
+        if(handler == null) {
+            handler = new ItemStackHandler(1);
+        }
+        return handler;
+    }
+
+    @SuppressWarnings("unchecked")
+	@Nonnull
+    @Override
+    public <T>LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side) {
+        if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY){
+            return LazyOptional.of(() -> (T) getHandler());
+        }
+        return super.getCapability(cap, side);
+    }
+}

--- a/src/main/java/com/rafacost3d/usrg/blocks/ModBlocks.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/ModBlocks.java
@@ -4,27 +4,20 @@ import net.minecraft.tileentity.TileEntityType;
 import net.minecraftforge.registries.ObjectHolder;
 
 public class ModBlocks {
-
-    @ObjectHolder("usrg:cobblegenerator")
-    public static CobblestoneGenerator COBBLEGENERATOR;
-    @ObjectHolder("usrg:cobblegenerator")
-    public static TileEntityType<CobblestoneGeneratorTile> COBBLEGENERATOR_TILE;
+	
+	// Vanilla Generators
     @ObjectHolder("usrg:claygenerator")
     public static ClayGenerator CLAYGENERATOR;
     @ObjectHolder("usrg:claygenerator")
     public static TileEntityType<ClayGeneratorTile> CLAYGENERATOR_TILE;
+    @ObjectHolder("usrg:cobblegenerator")
+    public static CobblestoneGenerator COBBLEGENERATOR;
+    @ObjectHolder("usrg:cobblegenerator")
+    public static TileEntityType<CobblestoneGeneratorTile> COBBLEGENERATOR_TILE;
     @ObjectHolder("usrg:dirtgenerator")
     public static DirtGenerator DIRTGENERATOR;
     @ObjectHolder("usrg:dirtgenerator")
     public static TileEntityType<DirtGeneratorTile> DIRTGENERATOR_TILE;
-    @ObjectHolder("usrg:dustgenerator")
-    public static DustGenerator DUSTGENERATOR;    
-    @ObjectHolder("usrg:dustgenerator")
-    public static TileEntityType<DustGeneratorTile> DUSTGENERATOR_TILE;    
-    @ObjectHolder("usrg:endcrushedgenerator")
-    public static CrushedEndstoneGenerator ENDCRUSHEDGENERATOR;
-    @ObjectHolder("usrg:endcrushedgenerator")
-    public static TileEntityType<CrushedEndstoneGeneratorTile> ENDCRUSHEDGENERATOR_TILE;
     @ObjectHolder("usrg:endgenerator")
     public static EndstoneGenerator ENDGENERATOR;
     @ObjectHolder("usrg:endgenerator")
@@ -49,10 +42,6 @@ public class ModBlocks {
     public static IceGenerator ICEGENERATOR;
     @ObjectHolder("usrg:icegenerator")
     public static TileEntityType<IceGeneratorTile> ICEGENERATOR_TILE;
-    @ObjectHolder("usrg:nethercrushedgenerator")
-    public static CrushedNetherGenerator NETHERCRUSHEDGENERATOR;
-    @ObjectHolder("usrg:nethercrushedgenerator")
-    public static TileEntityType<CrushedNetherGeneratorTile> NETHERCRUSHEDGENERATOR_TILE;
     @ObjectHolder("usrg:nethergenerator")
     public static NetherGenerator NETHERGENERATOR;
     @ObjectHolder("usrg:nethergenerator")
@@ -81,8 +70,28 @@ public class ModBlocks {
     public static SoulGenerator SOULGENERATOR;
     @ObjectHolder("usrg:soulgenerator")
     public static TileEntityType<SoulGeneratorTile> SOULGENERATOR_TILE;
+    
+    // Random Generators
+    @ObjectHolder("usrg:dyegenerator")
+    public static DyeGenerator DYEGENERATOR;
+    @ObjectHolder("usrg:dyegenerator")
+    public static TileEntityType<DyeGeneratorTile> DYEGENERATOR_TILE;
     @ObjectHolder("usrg:oregenerator")
     public static OreGenerator OREGENERATOR;
     @ObjectHolder("usrg:oregenerator")
     public static TileEntityType<OreGeneratorTile> OREGENERATOR_TILE;
+    
+    // Ex Nihilo: Sequentia generators
+    @ObjectHolder("usrg:dustgenerator")
+    public static DustGenerator DUSTGENERATOR;    
+    @ObjectHolder("usrg:dustgenerator")
+    public static TileEntityType<DustGeneratorTile> DUSTGENERATOR_TILE;
+    @ObjectHolder("usrg:endcrushedgenerator")
+    public static CrushedEndstoneGenerator ENDCRUSHEDGENERATOR;
+    @ObjectHolder("usrg:endcrushedgenerator")
+    public static TileEntityType<CrushedEndstoneGeneratorTile> ENDCRUSHEDGENERATOR_TILE;
+    @ObjectHolder("usrg:nethercrushedgenerator")
+    public static CrushedNetherGenerator NETHERCRUSHEDGENERATOR;
+    @ObjectHolder("usrg:nethercrushedgenerator")
+    public static TileEntityType<CrushedNetherGeneratorTile> NETHERCRUSHEDGENERATOR_TILE;
 }

--- a/src/main/java/com/rafacost3d/usrg/setup/Config.java
+++ b/src/main/java/com/rafacost3d/usrg/setup/Config.java
@@ -27,15 +27,19 @@ public class Config {
 
     public static ForgeConfigSpec.BooleanValue GENERATE_DUST;
     public static ForgeConfigSpec.IntValue BLOCK_PER_TICK;
+    public static ForgeConfigSpec.BooleanValue ENABLE_ORE_GENERATOR;
+    public static ForgeConfigSpec.BooleanValue ENABLE_DYE_GENERATOR;
     public static ForgeConfigSpec.ConfigValue<List<? extends String>> ORE_GENERATOR_ITEMS;
 
     static {
         COMMON_BUILDER.comment("General Settings").push(CATEGORY_GENERAL);
         GENERATE_DUST = COMMON_BUILDER.comment("Clay, Glowstone, Quartz, Redstone and Snow Generators will generate dust items, not blocks.").define("generate_dust", false);
         BLOCK_PER_TICK = COMMON_BUILDER.comment("Ticks between each generation cycle.").defineInRange("blocks_per_tick", 40, 1, 2000);
+        ENABLE_ORE_GENERATOR = COMMON_BUILDER.comment("Enable the Ore Generator.").define("oreGeneratorEnable", true);
+        ENABLE_DYE_GENERATOR = COMMON_BUILDER.comment("Enable the Dye Generator.").define("dyeGeneratorEnable", true);
         COMMON_BUILDER.pop();
 
-        COMMON_BUILDER.comment("OreGenerator Settings").push(CATEGORY_OREGEN);
+        COMMON_BUILDER.comment("Generator Settings").push(CATEGORY_OREGEN);
         COMMON_BUILDER.pop();
 
         COMMON_BUILDER.comment("OreGenerator Probabilities").push(CATEGORY_OREGEN);

--- a/src/main/resources/assets/usrg/blockstates/dyegenerator.json
+++ b/src/main/resources/assets/usrg/blockstates/dyegenerator.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": {"model": "usrg:block/dyegenerator"}
+  }
+}

--- a/src/main/resources/assets/usrg/lang/en_us.json
+++ b/src/main/resources/assets/usrg/lang/en_us.json
@@ -15,7 +15,9 @@
   "block.usrg.sandgenerator": "Sand Generator",
   "block.usrg.snowgenerator": "Snow Generator",
   "block.usrg.soulgenerator": "Soul Sand Generator",
+
   "block.usrg.oregenerator": "Ore Generator",
+  "block.usrg.dyegenerator": "Dye Generator",
 
   "block.usrg.dustgenerator": "Dust Generator",
   "block.usrg.endcrushedgenerator": "Crushed Endstone Generator",
@@ -23,6 +25,7 @@
 
   "block.holdshift.information": "Hold \u00A7eShift \u00A7ffor more information.",
   "block.generator.information": "Generates \u00A7e1 x {item} \u00A7fevery generation cycle of \u00A7e{ticks} \u00A7fticks.",
+  "block.dyegenerator.information": "Generates \u00A7e1 x random dye \u00A7fevery generation cycle of \u00A7e{ticks} \u00A7fticks.",
   "block.oregenerator.information": "Generates \u00A7e1 x random item \u00A7fevery generation cycle of \u00A7e{ticks} \u00A7fticks.",
 
   "_comment": "Creative Tabs",

--- a/src/main/resources/assets/usrg/models/block/dyegenerator.json
+++ b/src/main/resources/assets/usrg/models/block/dyegenerator.json
@@ -1,0 +1,116 @@
+{
+  "__comment": "Model generated using MrCrayfish's Model Creator (https://mrcrayfish.com/tools?id=mc)",
+  "textures": {
+    "MainTexture": "usrg:block/maintexture"
+  },
+  "display": {
+    "gui": {
+      "rotation": [ 30, 45, 0 ],
+      "translation": [ 0, 0, 0 ],
+      "scale": [ 0.625, 0.625, 0.625 ]
+    },
+    "ground": {
+      "rotation": [ 0, 0, 0 ],
+      "translation": [ 0, 3, 0 ],
+      "scale": [ 0.25, 0.25, 0.25 ]
+    },
+    "fixed": {
+      "rotation": [ 0, 180, 0 ],
+      "translation": [ 0, 0, 0 ],
+      "scale": [ 1, 1, 1 ]
+    },
+    "head": {
+      "rotation": [ 0, 180, 0 ],
+      "translation": [ 0, 0, 0 ],
+      "scale": [ 1, 1, 1 ]
+    },
+    "firstperson_righthand": {
+      "rotation": [ 0, 315, 0 ],
+      "translation": [ 0, 2.5, 0 ],
+      "scale": [ 0.4, 0.4, 0.4 ]
+    },
+    "thirdperson_righthand": {
+      "rotation": [ 75, 315, 0 ],
+      "translation": [ 0, 2.5, 0 ],
+      "scale": [ 0.375, 0.375, 0.375 ]
+    }
+  },
+  "elements": [
+    {
+      "name": "Cube",
+      "from": [ 0, 0, 0 ],
+      "to": [ 16, 6, 16 ],
+      "faces": {
+        "north": { "texture": "#MainTexture", "uv": [ 5, 0, 6, 1 ], "cullface": "north" },
+        "east": { "texture": "#MainTexture", "uv": [ 5, 0, 6, 1 ], "cullface": "east" },
+        "south": { "texture": "#MainTexture", "uv": [ 5, 0, 6, 1 ], "cullface": "south" },
+        "west": { "texture": "#MainTexture", "uv": [ 5, 0, 6, 1 ], "cullface": "west" },
+        "up": { "texture": "#MainTexture", "uv": [ 5, 0, 6, 1 ], "cullface": "up" },
+        "down": { "texture": "#MainTexture", "uv": [ 5, 0, 6, 1 ], "cullface": "down" }
+      }
+    },
+    {
+      "name": "Lava",
+      "from": [ 1, 6, 1 ],
+      "to": [ 6, 10, 15 ],
+      "faces": {
+        "north": { "texture": "#MainTexture", "uv": [ 14, 13, 13, 12 ], "cullface": "north" },
+        "east": { "texture": "#MainTexture", "uv": [ 14, 13, 13, 12 ], "cullface": "east" },
+        "south": { "texture": "#MainTexture", "uv": [ 14, 13, 13, 12 ], "cullface": "south" },
+        "west": { "texture": "#MainTexture", "uv": [ 14, 13, 13, 12 ], "cullface": "west" }
+      }
+    },
+    {
+      "name": "Water",
+      "from": [ 10, 6, 1 ],
+      "to": [ 15, 10, 15 ],
+      "faces": {
+        "north": { "texture": "#MainTexture", "uv": [ 14, 13, 13, 12 ], "cullface": "north" },
+        "east": { "texture": "#MainTexture", "uv": [ 14, 13, 13, 12 ], "cullface": "east" },
+        "south": { "texture": "#MainTexture", "uv": [ 14, 13, 13, 12 ], "cullface": "south" },
+        "west": { "texture": "#MainTexture", "uv": [ 14, 13, 13, 12 ], "cullface": "west" }
+      }
+    },
+    {
+      "name": "resource",
+      "from": [ 7, 7, 8 ],
+      "to": [ 9, 9, 10 ],
+      "rotation": { "origin": [ 8, 8, 8 ], "axis": "z", "angle": 45.0 },
+      "faces": {
+        "north": { "texture": "#MainTexture", "uv": [ 1, 5, 0, 4 ], "cullface": "north" },
+        "east": { "texture": "#MainTexture", "uv": [ 1, 5, 0, 4 ], "cullface": "east" },
+        "south": { "texture": "#MainTexture", "uv": [ 1, 5, 0, 4 ], "cullface": "south" },
+        "west": { "texture": "#MainTexture", "uv": [ 1, 5, 0, 4 ], "cullface": "west" },
+        "up": { "texture": "#MainTexture", "uv": [ 1, 5, 0, 4 ], "cullface": "up" },
+        "down": { "texture": "#MainTexture", "uv": [ 1, 5, 0, 4 ], "cullface": "down" }
+      }
+    },
+    {
+      "name": "Cube",
+      "from": [ 0, 10, 0 ],
+      "to": [ 16, 15, 16 ],
+      "faces": {
+        "north": { "texture": "#MainTexture", "uv": [ 5, 0, 6, 1 ], "cullface": "north" },
+        "east": { "texture": "#MainTexture", "uv": [ 5, 0, 6, 1 ], "cullface": "east" },
+        "south": { "texture": "#MainTexture", "uv": [ 5, 0, 6, 1 ], "cullface": "south" },
+        "west": { "texture": "#MainTexture", "uv": [ 5, 0, 6, 1 ], "cullface": "west" },
+        "up": { "texture": "#MainTexture", "uv": [ 5, 0, 6, 1 ], "cullface": "up" },
+        "down": { "texture": "#MainTexture", "uv": [ 5, 0, 6, 1 ], "cullface": "down" }
+      }
+    },
+    {
+      "name": "Tier",
+      "from": [ 4, 15, 4 ],
+      "to": [ 12, 16, 12 ],
+      "rotation": { "origin": [ 8, 8, 8 ], "axis": "y", "angle": 45.0 },
+      "faces": {
+        "north": { "texture": "#MainTexture", "uv": [ 8, 1, 7, 2 ], "cullface": "north" },
+        "east": { "texture": "#MainTexture", "uv": [ 8, 1, 7, 2 ], "cullface": "east" },
+        "south": { "texture": "#MainTexture", "uv": [ 8, 1, 7, 2 ], "cullface": "south" },
+        "west": { "texture": "#MainTexture", "uv": [ 8, 1, 7, 2 ], "cullface": "west" },
+        "up": { "texture": "#MainTexture", "uv": [ 8, 1, 7, 2 ], "cullface": "up" },
+        "down": { "texture": "#MainTexture", "uv": [ 8, 1, 7, 2 ], "cullface": "down" }
+      }
+    }
+  ]
+}

--- a/src/main/resources/assets/usrg/models/item/dyegenerator.json
+++ b/src/main/resources/assets/usrg/models/item/dyegenerator.json
@@ -1,0 +1,3 @@
+{
+  "parent": "usrg:block/dyegenerator"
+}

--- a/src/main/resources/data/usrg/loot_tables/blocks/dyegenerator.json
+++ b/src/main/resources/data/usrg/loot_tables/blocks/dyegenerator.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "pool1",
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "usrg:dyegenerator"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/usrg/recipes/dyegenerator.json
+++ b/src/main/resources/data/usrg/recipes/dyegenerator.json
@@ -1,0 +1,22 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "ppp",
+    "wcw",
+    "ppp"
+  ],
+  "key": {
+    "p": {
+      "item": "minecraft:golden_shovel"
+    },
+    "c": {
+      "tag": "forge:dyes"
+    },
+    "w": {
+      "item": "minecraft:water_bucket"
+    }
+  },
+  "result": {
+    "item": "usrg:dyegenerator"
+  }
+}


### PR DESCRIPTION
1. Added config to enable/disable OreGenerator.
2. Added config to enable/disable DyeGenerator.
3. Added new DyeGenerator, works like the ore generator, reads from the dyes tag, registered by forge.

NOTE: Recipe for Dye Generator uses 2 x water buckets, so have set the block model to show two water sections.